### PR TITLE
wp-content フォルダのマウント

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
      ports:
        - "8000:80"
      restart: always
+     volumes:
+       - ./wp-content:/var/www/html/wp-content
      environment:
        WORDPRESS_DB_HOST: db:3306
        WORDPRESS_DB_USER: wordpress


### PR DESCRIPTION
wp-content フォルダをマウントすることで、WordPress のテーマ開発が楽になる、らしい。